### PR TITLE
Add Chinese Simplified language (cn)

### DIFF
--- a/index.html
+++ b/index.html
@@ -2726,13 +2726,31 @@ function backendCalculation(camp) {
                     case 'zh-CN':
                       lingua = "cn";
                       break;
+                    case 'zh-SG':
+                      lingua = "cn";
+                      break;
                     case 'zh-TW':
+                      lingua = "zht";
+                      break;
+                    case 'zh-HK':
+                      lingua = "zht";
+                      break;
+                    case 'zh-MO':
                       lingua = "zht";
                       break;
                     case 'zh-cn':
                       lingua = "cn";
                       break;
+                    case 'zh-sg':
+                      lingua = "cn";
+                      break;
                     case 'zh-tw':
+                      lingua = "zht";
+                      break;
+                    case 'zh-hk':
+                      lingua = "zht";
+                      break;
+                    case 'zh-mo':
                       lingua = "zht";
                       break;
                     default:

--- a/index.html
+++ b/index.html
@@ -764,7 +764,191 @@ span.heroImgList {
             </span>
           </div>
           <div id="welcome_content">
-            <template v-if="lingua != 'zht'"> <!-- Welcome windows ENG content goes here -->
+            <template v-if="lingua == 'cn'"> <!-- Welcome windows Simplified CHINESE content goes here -->
+              <div id="welcome_message" style="height: 100%">
+                <h2 style="text-align: center;">{{strings.messaggio_di_benvenuto}}<br><a href="https://epicsevendb.com/" style="text-decoration: none;color:red"><u>{{strings.data_by}}</u></a>
+                </h2>
+                <div style="color: orangered; text-align: center;">
+                  寻找翻译者...
+              </div>
+              <!-- Copyright stuff if needed
+              <div style="width: 100%; position: absolute; bottom: 10%; text-align: center;">
+                All game content and assets are trademarks and copyrights of SUPERCREATIVE Corp and/or Smilegate Megaport.<br>
+                This site is fan made, not affiliated with SUPERCREATIVE Corp and/or Smilegate Megaport. 
+              </div>
+              -->
+            </div>
+            <div id="whats_new_content" style="display: none; max-height: 90%; overflow-y: auto;">
+              <ul>
+                <li style="color:rgb(255, 60, 0)">
+                  添加常用队伍统计!<br>
+                  在下方工具栏点击齿轮图标 -> "{{strings.most_saved_teams}}".
+                </li>
+                <li style="color:rgb(0, 255, 136)">
+              现在你可以选择结果的显示数量.<br>
+              使用方法: 选择 "高级设置" => 点击右上角齿轮图标 => 选中 "{{strings.numero_massimo_risultati}}" 或/与 "{{strings.morale_minimo_risultati}}" 然后输入相应的数量.<br>
+              请不要把 "{{strings.numero_massimo_risultati}}" 设置的很高 或者把"{{strings.morale_minimo_risultati}}" 设置得很低，你的浏览器很可能因为计算大量的结果而花费很长的加载时间.
+              默认显示心情最高的 200 个结果.
+            </li>
+            <li style="color:#007FFF">
+              新功能: "生成URL链接"<br>
+              在设置里选择生成URL链接将会生成一个保存了你英雄列表的链接.<br>
+              你可以在任何设备上使用这个链接.<br>
+              如果你用生成的链接打开将会覆盖当前设备已经保存的英雄列表.<br>
+              该功能仅用于跨设备/浏览器快速同步个人英雄列表，你的英雄列表依旧是自动保存的.
+            </li>
+            <li style="color:#007FFF">
+              设置里加入调试选项.<br>
+              打开可以右键(手机长按)查看对话列表.
+            </li>
+            <li>
+              默认语言将根据你浏览器的语言自动选择.<br>
+              你可以在设置里切换语言.
+            </li>
+            <li style="color:rgb(0, 255, 136)">
+              现在你可以选择德语，葡萄牙语，法语和西班牙语了.<br>
+            只有法语是菜单和数据完全翻译. 再次感谢 <a href="https://www.reddit.com/user/TriATK/">TriATK</a> 提供的法文翻译.<br>
+            德语，葡萄牙语，和西班牙语仅有数据翻译 (英雄名称, 对话, buffs 和 debuff) 如果你想提供翻译请联系我.<br>
+            </li>
+            <li style="color:rgb(0, 255, 136)">
+              添加简体中文，日文，韩文:<br>
+            日韩的菜单未翻译 游戏数据已翻译, 简中有完整的菜单和数据翻译.<br>
+            感谢 <a href="https://www.reddit.com/user/TriATK/">TriATK</a> 提供的中文翻译.<br>
+            </li>
+            <li>
+              添加通知功能:<br>
+            启用通知将会在计算完毕时发送通知.<br>
+            本功能适用于电脑端将网页放到后台时提示计算结果，并不会发送其它类型的通知!
+            </li>
+            <li style="color:rgb(0, 255, 136)">
+              添加锁定多人功能(Beta):<br>
+            添加你的英雄到4个栏位中 (每个栏位对应结果页上的相同位置), 如果你重复添加相同的英雄，最终结果里只会出现一次!
+            </li>
+            <li style="color:#007FFF">
+              现在你可以保存计算的结果:<br>
+            在结果页面点击 <i class="fa fa-floppy-o" aria-hidden="true"></i>  , 然后输入你自己定义的队伍名称并点击 "保存".<br>
+            你保存的队伍将显示在 <i class="fa fa-cog" aria-hidden="true"></i>  的设置窗口 你可以修改并删除他们.
+            </li>
+            <li>启动的时候会生成一个web worker用于处理计算结果, 这会保证你的浏览器不会出现 "页面失去响应".<br>
+         这个工具可以计算全部 35.208.615 种可能的排列组合并且不会崩溃 (运行中会保持低RAM占用率) 但是会花费更长的时间 (13-17 分钟, 锁定一个英雄后约 20 秒);
+          </li>
+              </ul>
+            </div>
+            <div id="instructions_content" style="display: none">
+            </div>
+            <div id="cool_websites_content" style="display: none; text-align: center; margin-top: 10%;">
+              不容错过的实用网站:
+              <p><a href="https://epicsevendb.com/">EpicSevenDB</a> by RaphaelDDL</p>
+              <p><a href="https://e7herder.com/">E7herder</a> 有非常酷的角色模型动画查看器</p>
+              <p><a href="https://maphe.github.io/e7-damage-calc/">Epic 7 伤害计算器</a> by Maphe</p>
+              <p><a href="https://www.e7leaks.com/">Epic 7 Leaks</a> by Maphe</p>
+              <p><a href="https://meowyih.github.io/epic7-gear/index.html?lang=en">装备评分计算器</a> by meowyih</p>
+              <p><a href="http://www.epicseventools.com/Home/LabMoraleOptimizer">E7 Tools</a> by Budandan</p>
+              <p><a href="https://gamepress.gg/epicseven/">GamePress.gg</a></p>
+            </div>
+            <div id="credits_content" style="display: none;">
+              <div style="width: 100vw; position: absolute; bottom: 10%; text-align: center;">
+              <br>英文地狱迷宫地图: <a href="https://www.reddit.com/user/C0NNECT1NG/">u/C0NNECT1NG</a> (<a href="https://www.reddit.com/r/EpicSeven/comments/flg4b1/complete_hell_raid_map/">Reddit post</a>)
+		      <br>普通迷宫地图&中文迷宫地图: TriATK
+              <br>中文/法文翻译: TriATK
+          <br>联系原作者(英语或意大利语): <a href="https://www.reddit.com/user/UsernameSniped/">u/UsernameSniped</a>
+	      <br>Discord: gio#0898
+                </div>
+              </div>
+            </template>
+            <template v-else-if="lingua == 'zht'"> <!-- Welcome windows Traditional CHINESE content goes here -->
+              <div id="welcome_message" style="height: 100%">
+                <h2 style="text-align: center;">{{strings.messaggio_di_benvenuto}}<br><a href="https://epicsevendb.com/" style="text-decoration: none;color:red"><u>{{strings.data_by}}</u></a>
+                </h2>
+                <div style="color: orangered; text-align: center;">
+                  尋找翻譯者...
+              </div>
+              <!-- Copyright stuff if needed
+              <div style="width: 100%; position: absolute; bottom: 10%; text-align: center;">
+                All game content and assets are trademarks and copyrights of SUPERCREATIVE Corp and/or Smilegate Megaport.<br>
+                This site is fan made, not affiliated with SUPERCREATIVE Corp and/or Smilegate Megaport. 
+              </div>
+              -->
+            </div>
+            <div id="whats_new_content" style="display: none; max-height: 90%; overflow-y: auto;">
+              <ul>
+                <li style="color:rgb(255, 60, 0)">
+                  添加常用隊伍統計!<br>
+                  在下方工具欄點擊齒輪圖標 -> "{{strings.most_saved_teams}}".
+                </li>
+                <li style="color:rgb(0, 255, 136)">
+              現在你可以選擇結果的顯示數量.<br>
+              使用方法: 選擇 "高級設置" => 點擊右上角齒輪圖標 => 選中 "{{strings.numero_massimo_risultati}}" 或/與 "{{strings.morale_minimo_risultati}}" 然後輸入相應的數量.<br>
+              請不要把 "{{strings.numero_massimo_risultati}}" 設置的很高 或者把"{{strings.morale_minimo_risultati}}" 設置得很低，你的瀏覽器很可能因為計算大量的結果而花費很長的加載時間.
+              默認顯示心情最高的 200 個結果.
+            </li>
+            <li style="color:#007FFF">
+              新功能: "生成URL鏈接"<br>
+              在設置裏選擇生成URL鏈接將會生成一個保存了你英雄列表的鏈接.<br>
+              你可以在任何設備上使用這個鏈接.<br>
+              如果你用生成的鏈接打開將會覆蓋當前設備已經保存的英雄列表.<br>
+              該功能僅用於跨設備/瀏覽器快速同步個人英雄列表，你的英雄列表依舊是自動保存的.
+            </li>
+            <li style="color:#007FFF">
+              設置裏加入調試選項.<br>
+              打開可以右鍵(手機長按)查看對話列表.
+            </li>
+            <li>
+              默認語言將根據你瀏覽器的語言自動選擇.<br>
+              你可以在設置裏切換語言.
+            </li>
+            <li style="color:rgb(0, 255, 136)">
+              現在你可以選擇德語，葡萄牙語，法語和西班牙語了.<br>
+            只有法語是菜單和數據完全翻譯. 再次感謝 <a href="https://www.reddit.com/user/TriATK/">TriATK</a> 提供的法文翻譯.<br>
+            德語，葡萄牙語，和西班牙語僅有數據翻譯 (英雄名稱, 對話, buffs 和 debuff) 如果你想提供翻譯請聯系我.<br>
+            </li>
+            <li style="color:rgb(0, 255, 136)">
+              添加簡體中文，日文，韓文:<br>
+            日韓的菜單未翻譯 遊戲數據已翻譯, 簡中有完整的菜單和數據翻譯.<br>
+            感謝 <a href="https://www.reddit.com/user/TriATK/">TriATK</a> 提供的中文翻譯.<br>
+            </li>
+            <li>
+              添加通知功能:<br>
+            啟用通知將會在計算完畢時發送通知.<br>
+            本功能適用於電腦端將網頁放到後臺時提示計算結果，並不會發送其它類型的通知!
+            </li>
+            <li style="color:rgb(0, 255, 136)">
+              添加鎖定多人功能(Beta):<br>
+            添加你的英雄到4個欄位中 (每個欄位對應結果頁上的相同位置), 如果你重復添加相同的英雄，最終結果裏只會出現一次!
+            </li>
+            <li style="color:#007FFF">
+              現在你可以保存計算的結果:<br>
+            在結果頁面點擊 <i class="fa fa-floppy-o" aria-hidden="true"></i>  , 然後輸入你自己定義的隊伍名稱並點擊 "保存".<br>
+            你保存的隊伍將顯示在 <i class="fa fa-cog" aria-hidden="true"></i>  的設置窗口 你可以修改並刪除他們.
+            </li>
+            <li>啟動的時候會生成一個web worker用於處理計算結果, 這會保證你的瀏覽器不會出現 "頁面失去響應".<br>
+         這個工具可以計算全部 35.208.615 種可能的排列組合並且不會崩潰 (運行中會保持低RAM占用率) 但是會花費更長的時間 (13-17 分鐘, 鎖定一個英雄後約 20 秒);
+          </li>
+              </ul>
+            </div>
+            <div id="instructions_content" style="display: none">
+            </div>
+            <div id="cool_websites_content" style="display: none; text-align: center; margin-top: 10%;">
+              不容錯過的實用網站:
+              <p><a href="https://epicsevendb.com/">EpicSevenDB</a> by RaphaelDDL</p>
+              <p><a href="https://e7herder.com/">E7herder</a> 有非常酷的角色模型動畫查看器</p>
+              <p><a href="https://maphe.github.io/e7-damage-calc/">Epic 7 傷害計算器</a> by Maphe</p>
+              <p><a href="https://www.e7leaks.com/">Epic 7 Leaks</a> by Maphe</p>
+              <p><a href="https://meowyih.github.io/epic7-gear/index.html?lang=en">裝備評分計算器</a> by meowyih</p>
+              <p><a href="http://www.epicseventools.com/Home/LabMoraleOptimizer">E7 Tools</a> by Budandan</p>
+              <p><a href="https://gamepress.gg/epicseven/">GamePress.gg</a></p>
+            </div>
+            <div id="credits_content" style="display: none;">
+              <div style="width: 100vw; position: absolute; bottom: 10%; text-align: center;">
+              <br>英文地獄迷宮地圖: <a href="https://www.reddit.com/user/C0NNECT1NG/">u/C0NNECT1NG</a> (<a href="https://www.reddit.com/r/EpicSeven/comments/flg4b1/complete_hell_raid_map/">Reddit post</a>)
+		      <br>普通迷宮地圖&中文迷宮地圖: TriATK
+              <br>中文/法文翻譯: TriATK
+          <br>聯系原作者(英語或意大利語): <a href="https://www.reddit.com/user/UsernameSniped/">u/UsernameSniped</a>
+	      <br>Discord: gio#0898
+                </div>
+              </div>
+            </template>
+            <template v-else> <!-- Welcome windows ENG content goes here -->
               <div id="welcome_message" style="height: 100%">
                 <h2 style="text-align: center;">{{strings.messaggio_di_benvenuto}}<br><a href="https://epicsevendb.com/" style="text-decoration: none;color:red"><u>{{strings.data_by}}</u></a>
                 </h2>
@@ -857,98 +1041,6 @@ span.heroImgList {
                   <br>Chinese/French translations: TriATK
                   <br>Contact me: <a href="https://www.reddit.com/user/UsernameSniped/">u/UsernameSniped</a>
                   <br>Discord: gio#0898
-                </div>
-              </div>
-            </template>
-            <template v-else> <!-- Welcome windows CHINESE content goes here -->
-              <div id="welcome_message" style="height: 100%">
-                <h2 style="text-align: center;">{{strings.messaggio_di_benvenuto}}<br><a href="https://epicsevendb.com/" style="text-decoration: none;color:red"><u>{{strings.data_by}}</u></a>
-                </h2>
-                <div style="color: orangered; text-align: center;">
-                  寻找翻译者...
-              </div>
-              <!-- Copyright stuff if needed
-              <div style="width: 100%; position: absolute; bottom: 10%; text-align: center;">
-                All game content and assets are trademarks and copyrights of SUPERCREATIVE Corp and/or Smilegate Megaport.<br>
-                This site is fan made, not affiliated with SUPERCREATIVE Corp and/or Smilegate Megaport. 
-              </div>
-              -->
-            </div>
-            <div id="whats_new_content" style="display: none; max-height: 90%; overflow-y: auto;">
-              <ul>
-                <li style="color:rgb(255, 60, 0)">
-                  添加常用队伍统计!<br>
-                  在下方工具栏点击齿轮图标 -> "{{strings.most_saved_teams}}".
-                </li>
-                <li style="color:rgb(0, 255, 136)">
-              现在你可以选择结果的显示数量.<br>
-              使用方法: 选择 "高级设置" => 点击右上角齿轮图标 => 选中 "{{strings.numero_massimo_risultati}}" 或/与 "{{strings.morale_minimo_risultati}}" 然后输入相应的数量.<br>
-              请不要把 "{{strings.numero_massimo_risultati}}" 设置的很高 或者把"{{strings.morale_minimo_risultati}}" 设置得很低，你的浏览器很可能因为计算大量的结果而花费很长的加载时间.
-              默认显示心情最高的 200 个结果.
-            </li>
-            <li style="color:#007FFF">
-              新功能: "生成URL链接"<br>
-              在设置里选择生成URL链接将会生成一个保存了你英雄列表的链接.<br>
-              你可以在任何设备上使用这个链接.<br>
-              如果你用生成的链接打开将会覆盖当前设备已经保存的英雄列表.<br>
-              该功能仅用于跨设备/浏览器快速同步个人英雄列表，你的英雄列表依旧是自动保存的.
-            </li>
-            <li style="color:#007FFF">
-              设置里加入调试选项.<br>
-              打开可以右键(手机长按)查看对话列表.
-            </li>
-            <li>
-              默认语言将根据你浏览器的语言自动选择.<br>
-              你可以在设置里切换语言.
-            </li>
-            <li style="color:rgb(0, 255, 136)">
-              现在你可以选择德语，葡萄牙语，法语和西班牙语了.<br>
-            只有法语是菜单和数据完全翻译. 再次感谢 <a href="https://www.reddit.com/user/TriATK/">TriATK</a> 提供的法文翻译.<br>
-            德语，葡萄牙语，和西班牙语仅有数据翻译 (英雄名称, 对话, buffs 和 debuff) 如果你想提供翻译请联系我.<br>
-            </li>
-            <li style="color:rgb(0, 255, 136)">
-              添加简体中文，日文，韩文:<br>
-            日韩的菜单未翻译 游戏数据已翻译, 简中有完整的菜单和数据翻译.<br>
-            感谢 <a href="https://www.reddit.com/user/TriATK/">TriATK</a> 提供的中文翻译.<br>
-            </li>
-            <li>
-              添加通知功能:<br>
-            启用通知将会在计算完毕时发送通知.<br>
-            本功能适用于电脑端将网页放到后台时提示计算结果，并不会发送其它类型的通知!
-            </li>
-            <li style="color:rgb(0, 255, 136)">
-              添加锁定多人功能(Beta):<br>
-            添加你的英雄到4个栏位中 (每个栏位对应结果页上的相同位置), 如果你重复添加相同的英雄，最终结果里只会出现一次!
-            </li>
-            <li style="color:#007FFF">
-              现在你可以保存计算的结果:<br>
-            在结果页面点击 <i class="fa fa-floppy-o" aria-hidden="true"></i>  , 然后输入你自己定义的队伍名称并点击 "保存".<br>
-            你保存的队伍将显示在 <i class="fa fa-cog" aria-hidden="true"></i>  的设置窗口 你可以修改并删除他们.
-            </li>
-            <li>启动的时候会生成一个web worker用于处理计算结果, 这会保证你的浏览器不会出现 "页面失去响应".<br>
-         这个工具可以计算全部 35.208.615 种可能的排列组合并且不会崩溃 (运行中会保持低RAM占用率) 但是会花费更长的时间 (13-17 分钟, 锁定一个英雄后约 20 秒);
-          </li>
-              </ul>
-            </div>
-            <div id="instructions_content" style="display: none">
-            </div>
-            <div id="cool_websites_content" style="display: none; text-align: center; margin-top: 10%;">
-              不容错过的实用网站:
-              <p><a href="https://epicsevendb.com/">EpicSevenDB</a> by RaphaelDDL</p>
-              <p><a href="https://e7herder.com/">E7herder</a> 有非常酷的角色模型动画查看器</p>
-              <p><a href="https://maphe.github.io/e7-damage-calc/">Epic 7 伤害计算器</a> by Maphe</p>
-              <p><a href="https://www.e7leaks.com/">Epic 7 Leaks</a> by Maphe</p>
-              <p><a href="https://meowyih.github.io/epic7-gear/index.html?lang=en">装备评分计算器</a> by meowyih</p>
-              <p><a href="http://www.epicseventools.com/Home/LabMoraleOptimizer">E7 Tools</a> by Budandan</p>
-              <p><a href="https://gamepress.gg/epicseven/">GamePress.gg</a></p>
-            </div>
-            <div id="credits_content" style="display: none;">
-              <div style="width: 100vw; position: absolute; bottom: 10%; text-align: center;">
-              <br>英文地狱迷宫地图: <a href="https://www.reddit.com/user/C0NNECT1NG/">u/C0NNECT1NG</a> (<a href="https://www.reddit.com/r/EpicSeven/comments/flg4b1/complete_hell_raid_map/">Reddit post</a>)
-		      <br>普通迷宫地图&中文迷宫地图: TriATK
-              <br>中文/法文翻译: TriATK
-          <br>联系原作者(英语或意大利语): <a href="https://www.reddit.com/user/UsernameSniped/">u/UsernameSniped</a>
-	      <br>Discord: gio#0898
                 </div>
               </div>
             </template>
@@ -2001,7 +2093,7 @@ function backendCalculation(camp) {
                     <center>` + this.strings.language + `</center><br>
                     <img src="https://upload.wikimedia.org/wikipedia/en/thumb/a/ae/Flag_of_the_United_Kingdom.svg/1200px-Flag_of_the_United_Kingdom.svg.png" width="105" height="70" onclick="app.cambiaLingua('en')">
                     <img src="https://upload.wikimedia.org/wikipedia/commons/thumb/0/09/Flag_of_South_Korea.svg/1200px-Flag_of_South_Korea.svg.png" width="105" height="70"  onclick="app.cambiaLingua('kr')">
-                    <img src="https://upload.wikimedia.org/wikipedia/commons/thumb/f/fa/Flag_of_the_People%27s_Republic_of_China.svg/1200px-Flag_of_the_People%27s_Republic_of_China.svg.png" width="105" height="70"  onclick="app.cambiaLingua('zht')">
+                    <img src="https://upload.wikimedia.org/wikipedia/commons/thumb/f/fa/Flag_of_the_People%27s_Republic_of_China.svg/1200px-Flag_of_the_People%27s_Republic_of_China.svg.png" width="105" height="70"  onclick="app.cambiaLingua('cn')">
                     <br><br>
                     <img src="https://upload.wikimedia.org/wikipedia/en/thumb/9/9e/Flag_of_Japan.svg/1200px-Flag_of_Japan.svg.png" width="105" height="70"  onclick="app.cambiaLingua('jp')">
                     <img src="https://upload.wikimedia.org/wikipedia/en/thumb/0/03/Flag_of_Italy.svg/1200px-Flag_of_Italy.svg.png" width="105" height="70"  onclick="app.cambiaLingua('it')">
@@ -2010,6 +2102,8 @@ function backendCalculation(camp) {
                     <img src="https://upload.wikimedia.org/wikipedia/en/thumb/9/9a/Flag_of_Spain.svg/1200px-Flag_of_Spain.svg.png" width="105" height="70"  onclick="app.cambiaLingua('es')">
                     <img src="https://upload.wikimedia.org/wikipedia/commons/thumb/5/5c/Flag_of_Portugal.svg/1280px-Flag_of_Portugal.svg.png" width="105" height="70"  onclick="app.cambiaLingua('pt')">
                     <img src="https://upload.wikimedia.org/wikipedia/commons/thumb/b/ba/Flag_of_Germany.svg/1200px-Flag_of_Germany.svg.png" width="105" height="70"  onclick="app.cambiaLingua('de')">
+                    <br><br>
+                    <img src="https://upload.wikimedia.org/wikipedia/commons/thumb/7/72/Flag_of_the_Republic_of_China.svg/1000px-Flag_of_the_Republic_of_China.svg.png" width="105" height="70"  onclick="app.cambiaLingua('zht')">
                     </div>
                     <div class="container">
                       <button type="button" onclick="$('#menu_lingua').remove(); $('body').removeClass('modal-open')" class="button_cancelbtn">` + this.strings.back_btn + `</button>
@@ -2297,16 +2391,7 @@ function backendCalculation(camp) {
             var titolo, contenuto;
             switch (argomento) { //HTML code is allowed
               case 'add_heroes_help':
-                if (this.lingua != "zht") { // translations should be moved where the other strings are
-                  titolo = "Add Heroes";
-                  contenuto = `Tap or click the portrait of a hero to add that hero to your roster.<br>
-                              Heroes in your roster will be used to calculate all possible combinations and return the best 200 combinations.<br>
-                              You can add as many heroes as you wish but the time needed to calculate all possible combinations will also increase.<br>
-                              Your roster will be saved and can be used everytime you visit this page without the need to add each hero everytime!<br>
-                              <br>
-                              If you are using the "List" display mode tap the "+" symbol to add a hero to your roster
-                              `;
-                } else {
+                if (this.lingua == "cn") { // translations should be moved where the other strings are
                   titolo = "添加英雄";
                   contenuto = `点击英雄头像将英雄添加到你的英雄列表.<br>
                              你的英雄列表里的所有英雄将会用于计算可能的排列组合并给出心情最高的前200个结果.<br>
@@ -2315,27 +2400,68 @@ function backendCalculation(camp) {
                              <br>
                              如果你使用的是"列表"视图(可在搜索框右方切换) 点击 "+" 号添加英雄至你的英雄列表
                             `;
+                } else if (this.lingua == "zht") { // translations should be moved where the other strings are
+                  titolo = "添加英雄";
+                  contenuto = `點擊英雄頭像將英雄添加到你的英雄列表.<br>
+                             你的英雄列表裏的所有英雄將會用於計算可能的排列組合並給出心情最高的前200個結果.<br>
+                             可添加的英雄沒有數量限制，添加英雄越多計算越慢.<br>
+                             你的英雄將會自動保存，不需要每次打開頁面都重新選擇，但是清除頁面Cookie將會丟失你保存的設置和英雄列表!<br>
+                             <br>
+                             如果你使用的是"列表"視圖(可在搜索框右方切換) 點擊 "+" 號添加英雄至你的英雄列表
+                            `;
+                } else {
+                  titolo = "Add Heroes";
+                  contenuto = `Tap or click the portrait of a hero to add that hero to your roster.<br>
+                              Heroes in your roster will be used to calculate all possible combinations and return the best 200 combinations.<br>
+                              You can add as many heroes as you wish but the time needed to calculate all possible combinations will also increase.<br>
+                              Your roster will be saved and can be used everytime you visit this page without the need to add each hero everytime!<br>
+                              <br>
+                              If you are using the "List" display mode tap the "+" symbol to add a hero to your roster
+                              `;
                 };
                 break;
               case 'manage_heroes_help':
-                if (this.lingua != "zht") {
+                if (this.lingua == "cn") {
+                  titolo = "英雄列表管理";
+                  contenuto = `在这个界面你可以查看所有保存的英雄.<br>
+                             点击英雄头像上的 "x" 就可以删除英雄.<br>
+                             点击英雄头像可以锁定英雄，被锁定的英雄将会出现在所有的计算结果中.<br>
+                             你可以点击下方的篝火图标计算露营心情，或者点击记事本图标添加高级选项.
+                            `;                  
+                } else if (this.lingua == "zht") {
+                  titolo = "英雄列表管理";
+                  contenuto = `在這個界面你可以查看所有保存的英雄.<br>
+                             點擊英雄頭像上的 "x" 就可以刪除英雄.<br>
+                             點擊英雄頭像可以鎖定英雄，被鎖定的英雄將會出現在所有的計算結果中.<br>
+                             你可以點擊下方的篝火圖標計算露營心情，或者點擊記事本圖標添加高級選項.
+                            `;                  
+                } else {
                   titolo = "Manage Heroes";
                   contenuto = `In this window you can view all the heroes currently in your roster.<br>
                               You can remove a hero by clicking the "x" at the bottom of the hero's portrait.<br>
                               You can lock a hero by clicking he's portrait, a lock symbol will appear near the portrait. A locked hero will appear in every team in the results page.<br>
                               You can calculate all the camping results for the current roster by clicking the bonfire icon in the toolbar or click the book icon to add advance settings.
                               `;
-                } else {
-                  titolo = "英雄列表管理";
-                  contenuto = `在这个界面你可以查看所有保存的英雄.<br>
-                             点击英雄头像上的 "x" 就可以删除英雄.<br>
-                             点击英雄头像可以锁定英雄，被锁定的英雄将会出现在所有的计算结果中.<br>
-                             你可以点击下方的篝火图标计算露营心情，或者点击记事本图标添加高级选项.
-                            `;
                 }; 
                 break
               case 'advanced_settings':
-                if (this.lingua != "zht") {
+                if (this.lingua == "cn") {
+                  titolo = "高级设置";
+                  contenuto = `这里可以进行高级设置.<br>
+                            <b style="color:red">被锁定的英雄不受高级设置影响</b><br><br>
+                            你可以选择任意数量的选项，但是某些选项有特殊的限制.<br>
+                            例如你在职业一栏勾选超过4个职业就会报错，因为一个队伍最多不超过4个人.<br>
+                            因为被锁定的英雄无视高级设置限制，所以如果你锁定了 "塔瑪林爾(偶像)" 然后在高级设置的职业一栏选中了精灵师，那么在计算结果中 除了偶像还会再添加一个精灵师. 对于Buff和Debuff也是同理<br>
+                            `;                 
+                } else if (this.lingua == "zht") {
+                  titolo = "高級設置";
+                  contenuto = `這裏可以進行高級設置.<br>
+                            <b style="color:red">被鎖定的英雄不受高級設置影響</b><br><br>
+                            你可以選擇任意數量的選項，但是某些選項有特殊的限制.<br>
+                            例如你在職業一欄勾選超過4個職業就會報錯，因為一個隊伍最多不超過4個人.<br>
+                            因為被鎖定的英雄無視高級設置限制，所以如果你鎖定了 "塔瑪林爾(偶像)" 然後在高級設置的職業一欄選中了精靈師，那麽在計算結果中 除了偶像還會再添加一個精靈師. 對於Buff和Debuff也是同理<br>
+                            `;                 
+                } else {
                   titolo = "Advanced settings";
                   contenuto = `Here you can costumize your camp results.<br>
                               <b style="color:red">Locked heroes are not subject to these restrictions</b><br><br>
@@ -2343,18 +2469,32 @@ function backendCalculation(camp) {
                               For example if you lock 5 classes or 5 elements you will get a team size error.<br>
                               Because locked heroes ignore advanced settings if you lock "Tamarinne" and select Soul weaver as a class you will get "Tamarinne" + another Soul weaver in every team. The same thing applies to Buffs and Debuffs<br>
                               `;
-                } else {
-                  titolo = "高级设置";
-                  contenuto = `这里可以进行高级设置.<br>
-                            <b style="color:red">被锁定的英雄不受高级设置影响</b><br><br>
-                            你可以选择任意数量的选项，但是某些选项有特殊的限制.<br>
-                            例如你在职业一栏勾选超过4个职业就会报错，因为一个队伍最多不超过4个人.<br>
-                            因为被锁定的英雄无视高级设置限制，所以如果你锁定了 "塔瑪林爾(偶像)" 然后在高级设置的职业一栏选中了精灵师，那么在计算结果中 除了偶像还会再添加一个精灵师. 对于Buff和Debuff也是同理<br>
-                            `;
                 };
                 break;
               case 'multi-lock':
-                if (this.lingua != "zht") {
+                if (this.lingua == "cn") {
+                  titolo = "锁定多人 帮助";
+                  contenuto = `每个栏位代表队伍里的一个位置, 每个栏位可以添加任意数量的英雄.<br>
+                             计算结果中的每一个位置，只会出现对应栏位中的英雄. 同一个英雄不能被添加到多个栏位中.<br>
+                             空白的栏位对应你的英雄列表中剩余的全部英雄.<br>
+                             如果你将所有的英雄加到前三个栏位中将会出现 "所有英雄添加完毕，已无英雄可添加至下一个栏位!" 的错误信息.<br>
+                             空白的栏位将会受到高级设置的影响.<br><br>
+                             每个栏位中被锁定的英雄将无视高级设置的影响.<br>
+                             如果你所有栏位都放入了英雄，同时又选择了任意一个高级设置， 将会报错 "队伍人数超过上限!" 并返回 0 个计算结果.<br>
+                             这个选项有助于创建自定义队伍, 比如你将你所有的骑士放在一个栏位中，那么你所有的计算结果里就必定会出现一个骑士!
+                             `;                  
+                } else if (this.lingua == "zht") {
+                  titolo = "鎖定多人 幫助";
+                  contenuto = `每個欄位代表隊伍裏的一個位置, 每個欄位可以添加任意數量的英雄.<br>
+                             計算結果中的每一個位置，只會出現對應欄位中的英雄. 同一個英雄不能被添加到多個欄位中.<br>
+                             空白的欄位對應你的英雄列表中剩余的全部英雄.<br>
+                             如果你將所有的英雄加到前三個欄位中將會出現 "所有英雄添加完畢，已無英雄可添加至下一個欄位!" 的錯誤信息.<br>
+                             空白的欄位將會受到高級設置的影響.<br><br>
+                             每個欄位中被鎖定的英雄將無視高級設置的影響.<br>
+                             如果你所有欄位都放入了英雄，同時又選擇了任意一個高級設置， 將會報錯 "隊伍人數超過上限!" 並返回 0 個計算結果.<br>
+                             這個選項有助於創建自定義隊伍, 比如你將你所有的騎士放在一個欄位中，那麽你所有的計算結果裏就必定會出現一個騎士!
+                             `;                  
+                } else {
                   titolo = "Multi lock help";
                   contenuto = `Each slot is a space in your team, on each slot you can add as many heroes as you wish.<br>
                               Only one of the Heroes locked for each slot will be in the results. The same hero can't be added on multiple slots.<br>
@@ -2365,32 +2505,27 @@ function backendCalculation(camp) {
                               If you fill all the slots and select any advanced settings you will get a "team size exceeded" error or 0 results.<br>
                               This option is useful to create costum rules, for example you can put all your knights in 1 slot and you will get a knight for each team in the results!
                               `;
-                } else {
-                  titolo = "锁定多人 帮助";
-                  contenuto = `每个栏位代表队伍里的一个位置, 每个栏位可以添加任意数量的英雄.<br>
-                             计算结果中的每一个位置，只会出现对应栏位中的英雄. 同一个英雄不能被添加到多个栏位中.<br>
-                             空白的栏位对应你的英雄列表中剩余的全部英雄.<br>
-                             如果你将所有的英雄加到前三个栏位中将会出现 "所有英雄添加完毕，已无英雄可添加至下一个栏位!" 的错误信息.<br>
-                             空白的栏位将会受到高级设置的影响.<br><br>
-                             每个栏位中被锁定的英雄将无视高级设置的影响.<br>
-                             如果你所有栏位都放入了英雄，同时又选择了任意一个高级设置， 将会报错 "队伍人数超过上限!" 并返回 0 个计算结果.<br>
-                             这个选项有助于创建自定义队伍, 比如你将你所有的骑士放在一个栏位中，那么你所有的计算结果里就必定会出现一个骑士!
-                             `;
                 }; 
                 break;
               case 'results_help':
-                if (this.lingua != "zht") {
+                if (this.lingua == "cn") {
+                  titolo = "计算结果";
+                  contenuto = `这里会出现根据你的设置筛选出的心情最高的前200个结果.<br>
+                             你的英雄列表里至少要有4个英雄才能显示结果.<br>
+                             你可以点击每个结果前面的图标保存对应的队伍 (会弹出一个窗口要求你自定义队伍名称), 你保存的队伍会出现在右下方齿轮图标的"设置"一栏里.
+                             `;                 
+                } else if (this.lingua == "zht") {
+                  titolo = "計算結果";
+                  contenuto = `這裏會出現根據你的設置篩選出的心情最高的前200個結果.<br>
+                             你的英雄列表裏至少要有4個英雄才能顯示結果.<br>
+                             你可以點擊每個結果前面的圖標保存對應的隊伍 (會彈出一個窗口要求你自定義隊伍名稱), 你保存的隊伍會出現在右下方齒輪圖標的"設置"一欄裏.
+                             `;                 
+                } else {
                   titolo = "Results";
                   contenuto = `Here are displayed the best 200 combinations for your roster and current advanced settings.<br>
                               You need at least 4 heroes in your current roster for any result to be displayed.<br>
                               You can click the floppy disk icon to save a specific team composition (you will be prompted to input a name for that team), your saved teams will be displayed in the settings window.
                               `;
-                } else {
-                  titolo = "计算结果";
-                  contenuto = `这里会出现根据你的设置筛选出的心情最高的前200个结果.<br>
-                             你的英雄列表里至少要有4个英雄才能显示结果.<br>
-                             你可以点击每个结果前面的图标保存对应的队伍 (会弹出一个窗口要求你自定义队伍名称), 你保存的队伍会出现在右下方齿轮图标的"设置"一栏里.
-                             `;
                 };
                 break;
               default:
@@ -2586,6 +2721,18 @@ function backendCalculation(camp) {
                       lingua = "kr";
                       break;
                     case 'zh':
+                      lingua = "cn";
+                      break;
+                    case 'zh-CN':
+                      lingua = "cn";
+                      break;
+                    case 'zh-TW':
+                      lingua = "zht";
+                      break;
+                    case 'zh-cn':
+                      lingua = "cn";
+                      break;
+                    case 'zh-tw':
                       lingua = "zht";
                       break;
                     default:
@@ -2603,7 +2750,12 @@ function backendCalculation(camp) {
                 var maphell = document.getElementById("map_hell");
                 mapnormal.setAttribute("src", "./img/Raid-Normal_zht.png");               
                 maphell.setAttribute("src", "./img/Raid-Hell_zht.png");
-                } else {
+                } else if (this.lingua == "cn") {
+                var mapnormal = document.getElementById("map_normal");
+                var maphell = document.getElementById("map_hell");
+                mapnormal.setAttribute("src", "./img/Raid-Normal_zht.png");               
+                maphell.setAttribute("src", "./img/Raid-Hell_zht.png");
+               } else {
                 var mapnormal = document.getElementById("map_normal");
                 var maphell = document.getElementById("map_hell");
                 mapnormal.setAttribute("src", "./img/Raid-Normal_en.png");               
@@ -2699,7 +2851,7 @@ function backendCalculation(camp) {
                   copia: "Copia",
                   language: "Lingua"
                 };
-              } else if (this.lingua == "zht") {
+              } else if (this.lingua == "cn") {
                 this.strings = {
                   welcome: "欢迎",
                   whats_new: "更新日志",
@@ -2761,10 +2913,10 @@ function backendCalculation(camp) {
                   normal: "普通",
                   hell: "地狱",
                   queen: "阿吉曼夏洛斯女王",
-                  arakahan: "捕食者阿拉哈坎(蜘蛛)",
-                  karkanis: "执行者卡尔卡努斯(镰刀虫)",
-                  vera: "侍从官培拉(蛆)",
-                  juleeve: "乔里夫议会(蚊子)",
+                  arakahan: "捕食者阿拉哈坎",
+                  karkanis: "执行者卡尔卡努斯",
+                  vera: "侍从官培拉",
+                  juleeve: "乔里夫议会",
                   save: "保存",
                   canc_btn: "取消",
                   back_btn: "返回",
@@ -2788,6 +2940,96 @@ function backendCalculation(camp) {
                   url_usage_help: "复制这个链接到新设备来导入你的英雄列表. <br>设备间并不会自动同步, 如果你修改了英雄列表，下次导入前需要重新生成URL链接.",
                   copia: "复制",
                   language: "语言"
+                };
+              } else if (this.lingua == "zht") {
+                this.strings = {
+                  welcome: "歡迎",
+                  whats_new: "更新日誌",
+                  websites: "實用鏈接",
+                  credits: "作者",
+                  messaggio_di_benvenuto: "歡迎使用第七史詩露營模擬器",
+                  data_by: "數據來源 EpicSevenDB",
+                  all: "全部",
+                  sort: "排序",
+                  modified: "按添加日期",
+                  name: "按英雄名稱",
+                  ingame_id: "按英雄ID",
+                  aggiungi: "添加英雄 ",
+                  i_tuoi_eroi: "你的英雄",
+                  cerca_eroe: "搜索..",
+                  impostazioni_avanzate: "高級設置",
+                  numero_massimo_risultati: "顯示結果數量",
+                  morale_minimo_risultati: "最低心情限制",
+                  disabilita_immagini_in_risultati: "結果頁不顯示英雄頭像 (如果你設定的顯示結果數量非常大，關閉英雄頭像顯示有助於提升性能)",
+                  deve_contenere_AoE: "隊伍必須包含 AoE",
+                  no_s1_debuffs: "S1不帶Debuff (挑釁, 睡眠 和暈眩除外)",
+                  no_debuffs: "技能不帶Debuff (挑釁, 睡眠 和暈眩除外)",
+                  classe: "職業",
+                  knight: "騎士",
+                  warrior: "戰士",
+                  thief: "盜賊",
+                  ranger: "射手",
+                  mage: "魔導士",
+                  "soul-weaver": "精靈師",
+                  fire: "火焰屬性",
+                  ice: "寒氣屬性",
+                  earth: "自然屬性",
+                  light: "光明屬性",
+                  dark: "黑暗屬性",
+                  elemento: "屬性",
+                  buff: "Buff",
+                  debuff: "Debuff",
+                  combinations: "可能的組合",
+                  multilock: "鎖定多人 (笛卡爾 出品)",
+                  multilock_slot: "欄位",
+                  add_to_slot: "添加到這個位置",
+                  add_selection: "添加",
+                  possibili_combinazioni: "可能的組合:",
+
+                  //Results window
+                  risultati: "結果",
+                  morale: "心情",
+                  team: "隊伍",
+                  topics: "對話",
+                  notification_title: "E7 露營模擬器",
+                  notification_ready: "結果計算完畢!",
+                  results_error: "錯誤",
+                  team_size_exceeded: "隊伍人數超過上限!",
+                  not_enough_heroes: "所有英雄添加完畢，已無英雄可添加至下一個欄位!",
+
+                  ///Result saving window:
+                  camp_name_field: "隊伍名稱",
+                  camp_name_placeholder: "你的隊伍名稱",
+                  normal: "普通",
+                  hell: "地獄",
+                  queen: "阿吉曼夏洛斯女王",
+                  arakahan: "捕食者阿拉哈坎",
+                  karkanis: "執行者卡爾卡努斯",
+                  vera: "侍從官培拉",
+                  juleeve: "喬裏夫議會",
+                  save: "保存",
+                  canc_btn: "取消",
+                  back_btn: "返回",
+                  error_no_name_provided: "隊伍名稱不能為空!",
+                  error_name_in_use: "該名稱已經被使用!",
+                  saved_message: "保存成功!",
+                  deleted_message: "刪除成功!",
+
+                  impostazioni: "設置",
+                  my_teams: "我的隊伍",
+                  most_saved_teams: "常用隊伍&英雄",
+                  refresh_team_stats: "刷新",
+                  heroes: "英雄",
+                  teams: "隊伍",
+                  extras_map: "迷宮最佳路線",
+
+                  tema_notturno: "夜間模式",
+                  notifiche: "啟用通知",
+                  debug_camping_values: "調試: 顯示所有對話心情值",
+                  genera_url: "生成URL鏈接",
+                  url_usage_help: "復制這個鏈接到新設備來導入你的英雄列表. <br>設備間並不會自動同步, 如果你修改了英雄列表，下次導入前需要重新生成URL鏈接.",
+                  copia: "復制",
+                  language: "語言"
                 };
               }else if (this.lingua == "fr") {
                 this.strings = {
@@ -3103,6 +3345,41 @@ function backendCalculation(camp) {
                 this.strings["earth"] = "자연속성";
                 this.strings["light"] = "광속성";
                 this.strings["dark"] = "암속성";
+              } else if (lingua == "cn") {
+                this.buffList["stic_debuf_impossible"].name = "免疫";
+                this.buffList["stic_att_up"].name = "攻击力增加";
+                this.buffList["stic_att_up2"].name = "攻击力大幅增加";
+                this.buffList["stic_def_up"].name = "防御力增加";
+                this.buffList["stic_speed_up"].name = "速度提升";
+                this.buffList["stic_dodge_up"].name = "增加回避";
+                this.buffList["stic_protect"].name = "防护罩";
+                this.buffList["stic_cri_up"].name = "暴击率增加";
+                this.buffList["stic_cridmg_up"].name = "增加暴击伤害";
+                this.buffList["stic_crires_up"].name = "暴击抗性增加";
+                this.buffList["stic_invincible"].name = "无敌";
+                this.buffList["stic_endure"].name = "技能伤害无效";
+                this.buffList["stic_heal"].name = "持续恢复";
+                this.buffList["stic_hide"].name = "隐身";
+                this.buffList["stic_immortality"].name = "不死";
+                this.buffList["stic_reflect"].name = "反射";
+                this.buffList["stic_counter"].name = "反击";
+
+                this.debuffList["stic_def_dn"].name = "防御力减少";
+                this.debuffList["stic_speed_dn"].name = "速度下降";
+                this.debuffList["stic_att_dn"].name = "攻击力减少";
+                this.debuffList["stic_blind"].name = "命中减少";
+                this.debuffList["stic_target"].name = "标靶";
+                this.debuffList["stic_buf_impossible"].name = "无法强化";
+                this.debuffList["stic_heal_impossible"].name = "无法恢复";
+                this.debuffList["stic_stun"].name = "晕眩";
+                this.debuffList["stic_provoke"].name = "挑衅";
+                this.debuffList["stic_silence"].name = "沉默";
+                this.debuffList["stic_sleep"].name = "睡眠";
+                this.debuffList["stic_blood"].name = "出血";
+                this.debuffList["stic_dot"].name = "中毒";
+                this.debuffList["stic_blaze"].name = "烧伤";
+                this.debuffList["stic_vampire"].name = "吸血之手";
+                this.debuffList["stic_bomb"].name = "炸弹";
               } else if (lingua == "zht") {
                 this.buffList["stic_debuf_impossible"].name = "免疫";
                 this.buffList["stic_att_up"].name = "攻擊力增加";
@@ -3348,6 +3625,78 @@ function backendCalculation(camp) {
                 break;
               case 'Interesting Story':
                 return '冒険話';
+                break;
+              default:
+                return n;
+                break;
+            };
+          } else if (this.lingua == "cn") {
+            switch (n) {
+              case 'Criticism':
+                return '批判世界';
+                break;
+              case 'Reality Check':
+                return '正视现实';
+                break;
+              case 'Heroic Tale':
+                return '英雄故事';
+                break;
+              case 'Comforting Cheer':
+                return '安慰助阵';
+                break;
+              case 'Cute Cheer':
+                return '撒娇助阵';
+                break;
+              case 'Heroic Cheer':
+                return '英雄式助阵';
+                break;
+              case 'Sad Memory':
+                return '伤心回忆';
+                break;
+              case 'Joyful Memory':
+                return '愉快回忆';
+                break;
+              case 'Happy Memory':
+                return '幸福回忆';
+                break;
+              case 'Unique Comment':
+                return '4次元的发言';
+                break;
+              case 'Self-Indulgent':
+                return '自我陶醉';
+                break;
+              case 'Occult':
+                return '秘术';
+                break;
+              case 'Myth':
+                return '神话';
+                break;
+              case 'Bizarre Story':
+                return '猎奇的故事';
+                break;
+              case 'Food Story':
+                return '食物故事';
+                break;
+              case 'Horror Story':
+                return '恐怖故事';
+                break;
+              case 'Gossip':
+                return '八卦';
+                break;
+              case 'Dream':
+                return '梦';
+                break;
+              case 'Advice':
+                return '烦恼谘询';
+                break;
+              case 'Complain':
+                return '耍赖';
+                break;
+              case 'Belief':
+                return '信念';
+                break;
+              case 'Interesting Story':
+                return '冒险故事';
                 break;
               default:
                 return n;


### PR DESCRIPTION
I'm helping EpicSevenDB to add Chinese Simplified language.
Now it's online. 
The Chinese Simplified language code is cn.
example: https://api.epicsevendb.com/hero?lang=cn 

also add support for all countries and regions speaks Chinese including:
Mainland China(zh-CN)
Hong Kong (zh-HK)
Macau(zh-MO)
Taiwan(zh-TW)
Singapore(zh-SG)